### PR TITLE
Remove deprecated power hint from power HAL LineageOS/android_hardware_libhardware@aef9ca3

### DIFF
--- a/power/power.c
+++ b/power/power.c
@@ -81,7 +81,6 @@ static void power_hint(struct power_module *module, power_hint_t hint,
         case POWER_HINT_INTERACTION:
         case POWER_HINT_CPU_BOOST:
         case POWER_HINT_LAUNCH_BOOST:
-        case POWER_HINT_AUDIO:
         case POWER_HINT_SET_PROFILE:
         case POWER_HINT_VIDEO_ENCODE:
         case POWER_HINT_VIDEO_DECODE:


### PR DESCRIPTION
It is currently not possible to compile the power HAL due to missing declaration of the POWER_HINT_AUDIO. As it's not necessary in our case, I suggest to just remove it from the switch clause.